### PR TITLE
Don't pass original messages into sort

### DIFF
--- a/lib/causal-order.js
+++ b/lib/causal-order.js
@@ -11,44 +11,40 @@ function makeMsgRef(k) {
 
 module.exports = function causalOrder(messages) {
 
-  //const replacements = {}
-  const thread = Object.keys(messages).map(k => {
+  const replacementKeys = {}
+  const thread = Object.keys(messages).map((k, i) => {
     const newKey = makeMsgRef(k)
-    /*
     if (newKey !== k) {
-      replacements['KEY_' + newKey] = k
-    }*/
-      
-    const msg = {
-      key: newKey,
-      value: {
-        __orig: {key: k, value: messages[k]}
-      }
+      replacementKeys[newKey] = k
     }
+    const msgForSort = {
+      key: newKey,
+      timestamp: i,
+      value: {}
+    }
+      
     traverse(messages[k]).forEach(function(x) {
-      if (typeof x == 'string' && x[0] == '%' && !isMsg(x)) {
+      if (typeof x == 'string' && x[0] == '%') {
+        if(!isMsg(x)) {
         const newX = makeMsgRef(x)
-        //replacements[newX] = x
-        msg.value[x.slice(1)] = newX
-        //this.update(newX)
+        msgForSort.value[x.slice(1)] = newX
+        } else if (!isMsg(x)) {
+          msgForSort.value[x.slice(1)] = x
+        }
       }
     })
-    return msg
+    return msgForSort
   })
   const sortedThread = causalSort(thread)
   debug('sorted thread: %O', sortedThread)
-  /*
   return sortedThread.map(msg => {
-    if (replacements['KEY_' + msg.key]) {
-      msg.key = replacements['KEY_' + msg.key]
-    }
-    traverse(msg.value).forEach( function(x) {
-      if (replacements[x]) {
-        this.update(replacements[x])
+    if (replacementKeys[msg.key]) {
+      const orig = replacementKeys[msg.key]
+      return {
+        key: orig,
+        value: messages[orig]
       }
-    })
+    }
     return msg
   })
-  */
-  return sortedThread.map(kv => kv.value.__orig)
 }


### PR DESCRIPTION
Instead, make an inventary of their old and new keys. Also, use a fake timestamp so `ssb-sort` sorts correctly.